### PR TITLE
Use Kubereq.attach/2 in place of deprecated Kubereq.new/2

### DIFF
--- a/lib/kubegen/resource.ex
+++ b/lib/kubegen/resource.ex
@@ -71,7 +71,7 @@ defmodule Kubegen.Resource do
         defp req() do
           unquote(kubeconfig_pipeline)
           |> Kubereq.Kubeconfig.load()
-          |> Kubereq.new(@resource_path)
+          |> Kubereq.attach(@resource_path)
         end
       end
 

--- a/lib/kubegen/resource.ex
+++ b/lib/kubegen/resource.ex
@@ -71,7 +71,7 @@ defmodule Kubegen.Resource do
         defp req() do
           unquote(kubeconfig_pipeline)
           |> Kubereq.Kubeconfig.load()
-          |> Kubereq.attach(@resource_path)
+          |> Kubereq.attach(resource_path: @resource_path)
         end
       end
 


### PR DESCRIPTION
This fixes warnings issued by generated modules:
```
    warning: Kubereq.new/2 is deprecated. Use Kubereq.attach/2
    │
  5 │     Kubereq.Kubeconfig.Default |> Kubereq.Kubeconfig.load() |> Kubereq.new(@resource_path)
```

See #37 